### PR TITLE
Expectations eval pt 1

### DIFF
--- a/lib/wanda/expectations/expectations.ex
+++ b/lib/wanda/expectations/expectations.ex
@@ -1,0 +1,17 @@
+defmodule Wanda.Expectations do
+  @moduledoc """
+  This modules provides expectations functionalities.
+  """
+
+  alias Wanda.Facts.Fact
+
+  @spec execute(expression :: String.t(), facts :: [Fact]) :: {:ok, number()} | {:error, any}
+  def execute(expression, facts) do
+    variables =
+      Enum.into(facts, %{}, fn %Fact{name: name, value: value} ->
+        {name, value}
+      end)
+
+    Abacus.eval(expression, variables)
+  end
+end

--- a/lib/wanda/facts/fact.ex
+++ b/lib/wanda/facts/fact.ex
@@ -1,0 +1,10 @@
+defmodule Wanda.Facts.Fact do
+  @moduledoc """
+  A fact is a piece of information that was gathered from a target.
+  """
+
+  defstruct [
+    :name,
+    :value
+  ]
+end

--- a/lib/wanda/facts/gathering.ex
+++ b/lib/wanda/facts/gathering.ex
@@ -22,19 +22,6 @@ defmodule Wanda.Facts.Gathering do
     :ok
   end
 
-  defmodule Fact do
-    @moduledoc """
-    A representation of a Fact that can be serialized and sent to the targets as part of the message initiating facts gathering
-    """
-
-    @derive Jason.Encoder
-    defstruct [
-      :name,
-      :gatherer,
-      :argument
-    ]
-  end
-
   @spec extract_facts(checks) :: [map]
   defp extract_facts(checks) do
     # given the checks identifiers we can retieve their information (facts gathering DSL mainly)

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Wanda.MixProject do
   defp deps do
     [
       {:elixir_uuid, "~> 1.2"},
+      {:abacus, "~> 0.4.2"},
       {:yaml_elixir, "~> 2.9"},
       {:jason, "~> 1.3"},
       {:amqp, "~> 3.1"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "abacus": {:hex, :abacus, "0.4.2", "632837177bd534e55a520d373b7195bc9bfcbc9425fefb5e93e3cf3336ba9737", [:mix], [], "hexpm", "2e7bd7c0ba2a594808d42c1b946f11c47bf8254506403031958b58054c807986"},
   "amqp": {:hex, :amqp, "3.1.1", "a96ee272d196dfd1bf4ffc15dc7dcf900004d928dbdc6f5fcb80e6b0da03927c", [:mix], [{:amqp_client, "~> 3.9.1", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "ee7ca576351b4629b6be0701db8c085e203e242c577c59f344be56ef5a262056"},
   "amqp_client": {:hex, :amqp_client, "3.9.20", "1d95c0401cc6ea9a5cabd583c59f0cdd5ac534109976078f16942848e2774d37", [:make, :rebar3], [{:rabbit_common, "3.9.20", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "3945ab858fd99c343745485f9c5e12f9f7ec878e84e40f986e326c6d8d060aea"},
   "credentials_obfuscation": {:hex, :credentials_obfuscation, "3.1.0", "2c405ea0c5db7b3344aa5a99f86c33e7b6ecea97d2cb613371e1cf0d192ef2c6", [:rebar3], [], "hexpm", "04884e62b1c6cdfba999d4d6b3e99bc0a59d5e439517bc5c01767255afb7b778"},

--- a/test/expectations/expectations_test.exs
+++ b/test/expectations/expectations_test.exs
@@ -1,0 +1,16 @@
+defmodule Wanda.ExpectationsTest do
+  use ExUnit.Case
+
+  alias Wanda.Facts.Fact
+
+  test "should eval the expression and return a result" do
+    facts = [
+      %Fact{name: "foo", value: 20000},
+      %Fact{name: "bar", value: "baz"}
+    ]
+
+    result = Wanda.Expectations.execute("foo == 20000 && bar == \"baz\"", facts)
+
+    assert {:ok, true} == result
+  end
+end

--- a/test/fixtures/check-definition.yaml
+++ b/test/fixtures/check-definition.yaml
@@ -10,13 +10,12 @@ check_corosync_token_timeout:
     ## Remediation
     ...
   facts:
-    -
-      name: corosync_token_timeout
+    - name: corosync_token_timeout
       gatherer: corosync
       argument: totem.token
-    -
-      name: some_other_fact_useful_for_this_check
+    - name: some_other_fact_useful_for_this_check
       gatherer: another_reference_to_a_gatherer
       argument: something_else
   expectations:
-    TDB: TBD
+    - name: timeout
+      expect: corosync_token_timeout == 30000

--- a/test/wanda_test.exs
+++ b/test/wanda_test.exs
@@ -1,8 +1,0 @@
-defmodule WandaTest do
-  use ExUnit.Case
-  doctest Wanda
-
-  test "greets the world" do
-    assert Wanda.hello() == :world
-  end
-end


### PR DESCRIPTION
This PR adds expectation evaluation to wanda through [abacus](https://github.com/narrowtux/abacus).

This means we can now do stuff like this:

```yaml
  facts:
    - name: corosync_token_timeout
      gatherer: corosync
      argument: totem.token
  expectations:
    - name: timeout
      expect: corosync_token_timeout == 30000
```

`|| &&` and ternary operator are supported too

